### PR TITLE
Add auto-installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,62 @@
-#!/bin/sh
+#!/bin/bash
 version=0.1.3
-# if the 1st command fails, the second will activate.
-keyboard=$(ls /dev/input/by-id/*kbd* || ls /dev/input/by-path/*kbd* | head -n1)
+keyboard1=$(ls /dev/input/by-id/*kbd*)
+keyboard2=$(ls /dev/input/by-path/*kbd* | head -n1)
 temporary=/tmp/mouseless
-# nv means no verbose
-wget -P $temporary https://github.com/jbensmann/mouseless/releases/download/v$version/mouseless-linux-amd64.tar.gz
-tar -xf $temporary/mouseless-linux-amd64.tar.gz --directory $temporary
-sudo cp $temporary/dist/mouseless /usr/local/bin/
-# copies the default config to the .config directory
-mkdir /home/$USER/.config/mouseless
-touch /home/$USER/.config/mouseless/config.yaml 
-echo "
+echo "=========================================="
+echo "Install mouseless version $version? [y/n]"
+echo "=========================================="
+read choice
+if [ "$choice" == "y" ];
+then 
+	echo "Installing."
+	wget -P $temporary https://github.com/jbensmann/mouseless/releases/download/v$version/mouseless-linux-amd64.tar.gz
+	tar -xf $temporary/mouseless-linux-amd64.tar.gz --directory $temporary
+	# removes the old version
+	sudo rm /usr/local/bin/mouseless
+	sudo cp $temporary/dist/mouseless /usr/local/bin/
+else
+	
+echo "=========================================="
+	echo "Skipping."
+echo "=========================================="
+fi
+echo "=========================================="
+echo "Install an executable file that allows launching mouseless alongside the config file in a single command? [y/n]"
+echo "=========================================="
+read choice
+if [ "$choice" == "y" ];
+then
+	echo "Type in the command's name."
+	read scriptname
+    touch $temporary/$scriptname
+	echo "
+#!/bin/sh 
+sudo mouseless --config ~/.config/mouseless/config.yaml" > $temporary/$scriptname
+chmod +x $temporary/$scriptname
+sudo cp $temporary/$scriptname /usr/local/bin/
+else
+	
+	echo "=========================================="
+	echo "Script will NOT be installed."
+	echo "=========================================="
+fi
+
+
+
+echo "=========================================="
+echo "Create a config file? (Choose no in case you have already created one.) [y/n]"
+echo "=========================================="
+read choice
+if [ "$choice" == "y" ];
+then
+	mkdir /home/$USER/.config/mouseless
+	touch /home/$USER/.config/mouseless/config.yaml 
+	echo " 
 devices:
 # change this to a keyboard device
-- "$keyboard"
+- "$keyboard1"
+- "$keyboard2"
 # this is executed when mouseless starts
 # startCommand: ""
 # the default speed for mouse movement
@@ -69,12 +112,10 @@ layers:
     w: backspace
     r: delete
     v: enter" > /home/$USER/.config/mouseless/config.yaml 
-# Creates an entry that automatically launches mouseless with the --config flag
-touch $temporary/mouseless-execute
-echo "
-#!/bin/sh 
-sudo mouseless --config ~/.config/mouseless/config.yaml" > $temporary/mouseless-execute
-chmod +x $temporary/mouseless-execute
-sudo cp $temporary/mouseless-execute /usr/local/bin/
-# Removes the downloaded files
-echo "Installation complete. Type mouseless-execute to launch the app alongside the config file. If you want to use other flags, use mouseless. If you wish do delete these entries, type sudo rm /usr/local/bin/mouseless /usr/local/bin/mouseless-execute."
+else
+	echo "Config file will NOT be created."
+fi
+
+echo "=========================================="
+echo "Installation complete." 
+echo "=========================================="

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ layers:
     r: delete
     v: enter" > /home/$USER/.config/mouseless/config.yaml 
 # Creates an entry that automatically launches mouseless with the --config flag
-touch mouseless-execute
+touch /home/$USER/mouseless-execute
 echo "
 #!/bin/sh 
 sudo mouseless --config ~/.config/mouseless/config.yaml" > /home/$USER/mouseless-execute

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 version=0.1.3
 # if the 1st command fails, the second will activate.
-keyboard=$(ls /dev/input/by-id/*kbd* || ls /dev/input/by-path/*kbd*)
+keyboard=$(ls /dev/input/by-id/*kbd* || ls /dev/input/by-path/*kbd* | head -n1)
+temporary=/tmp/mouseless
 # nv means no verbose
-wget -P /home/$USER/ https://github.com/jbensmann/mouseless/releases/download/v$version/mouseless-linux-amd64.tar.gz
-tar -xf /home/$USER/mouseless-linux-amd64.tar.gz --directory /home/$USER/
-sudo cp /home/$USER/dist/mouseless /bin/
+wget -P $temporary https://github.com/jbensmann/mouseless/releases/download/v$version/mouseless-linux-amd64.tar.gz
+tar -xf $temporary/mouseless-linux-amd64.tar.gz --directory $temporary
+sudo cp $temporary/dist/mouseless /usr/local/bin/
 # copies the default config to the .config directory
 mkdir /home/$USER/.config/mouseless
 touch /home/$USER/.config/mouseless/config.yaml 
@@ -69,13 +70,11 @@ layers:
     r: delete
     v: enter" > /home/$USER/.config/mouseless/config.yaml 
 # Creates an entry that automatically launches mouseless with the --config flag
-touch /home/$USER/mouseless-execute
+touch $temporary/mouseless-execute
 echo "
 #!/bin/sh 
-sudo mouseless --config ~/.config/mouseless/config.yaml" > /home/$USER/mouseless-execute
-chmod +x /home/$USER/mouseless-execute
-sudo cp /home/$USER/mouseless-execute /bin/
+sudo mouseless --config ~/.config/mouseless/config.yaml" > $temporary/mouseless-execute
+chmod +x $temporary/mouseless-execute
+sudo cp $temporary/mouseless-execute /usr/local/bin/
 # Removes the downloaded files
-rm /home/$USER/mouseless-execute /home/$USER/mouseless-linux-amd64.tar.gz
-rm -r /home/$USER/dist
-echo "Installation complete. Type mouseless-execute to launch the app alongside the config file. If you want to use other flags, use mouseless. If you wish do delete these entries, type sudo rm /bin/mouseless /bin/mouseless-execute."
+echo "Installation complete. Type mouseless-execute to launch the app alongside the config file. If you want to use other flags, use mouseless. If you wish do delete these entries, type sudo rm /usr/local/bin/mouseless /usr/local/bin/mouseless-execute."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+version=0.1.3
+# if the 1st command fails, the second will activate.
+keyboard=$(ls /dev/input/by-id/*kbd* || ls /dev/input/by-path/*kbd*)
+# nv means no verbose
+wget -P /home/$USER/ https://github.com/jbensmann/mouseless/releases/download/v$version/mouseless-linux-amd64.tar.gz
+tar -xf /home/$USER/mouseless-linux-amd64.tar.gz --directory /home/$USER/
+sudo cp /home/$USER/dist/mouseless /bin/
+# copies the default config to the .config directory
+mkdir /home/$USER/.config/mouseless
+touch /home/$USER/.config/mouseless/config.yaml 
+echo "
+devices:
+# change this to a keyboard device
+- "$keyboard"
+# this is executed when mouseless starts
+# startCommand: ""
+# the default speed for mouse movement
+baseMouseSpeed: 750.0
+# the default speed for scrolling
+baseScrollSpeed: 20.0
+layers:
+# the first layer is active at start
+- name: initial
+  bindings:
+    # when tab is held and another key pressed, activate mouse layer
+    tab: tap-hold-next tab ; toggle-layer mouse ; 500
+    # when a is held for 300ms, activate mouse layer
+    a: tap-hold a ; toggle-layer mouse ; 300
+    # right alt key toggles arrows layer
+    rightalt: toggle-layer arrows
+    # switch escape with capslock
+    esc: capslock
+    capslock: esc
+# a layer for mouse movement
+- name: mouse
+  # when true, keys that are not mapped keep their original meaning
+  passThrough: true
+  bindings:
+    # quit mouse layer
+    q: layer initial
+    # keep the mouse layer active
+    space: layer mouse
+    r: reload-config
+    l: move  1  0
+    j: move -1  0
+    k: move  0  1
+    i: move  0 -1
+    p: scroll up
+    n: scroll down
+    leftalt: speed 4.0
+    e: speed 0.3
+    capslock: speed 0.1
+    f: button left
+    d: button middle
+    s: button right
+    # move to the top left corner
+    k0: "exec xdotool mousemove 0 0"
+# another layer for arrows and some other keys
+- name: arrows
+  passThrough: true
+  bindings:
+    e: up
+    s: left
+    d: down
+    f: right
+    q: esc
+    w: backspace
+    r: delete
+    v: enter" > /home/$USER/.config/mouseless/config.yaml 
+# Creates an entry that automatically launches mouseless with the --config flag
+touch mouseless-execute
+echo "
+#!/bin/sh 
+sudo mouseless --config ~/.config/mouseless/config.yaml" > /home/$USER/mouseless-execute
+chmod +x /home/$USER/mouseless-execute
+sudo cp /home/$USER/mouseless-execute /bin/
+# Removes the downloaded files
+rm /home/$USER/mouseless-execute /home/$USER/mouseless-linux-amd64.tar.gz
+rm -r /home/$USER/dist
+echo "Installation complete. Type mouseless-execute to launch the app alongside the config file. If you want to use other flags, use mouseless. If you wish do delete these entries, type sudo rm /bin/mouseless /bin/mouseless-execute."


### PR DESCRIPTION
An attempt on an installation script that creates the config directory, adds in the example config file, places the binaries in their correct folders (/bin), and adds in a script launching mouseless with the --config flag.