### PR TITLE
README: Adjust the command to create an udev rule file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,10 @@ To run without using sudo, you can add an udev rule with the following command, 
 keyboard devices and create a virtual keyboard and mouse:
 
 ```sh
-echo "KERNEL==\"uinput\", GROUP=\"$USER\", MODE:=\"0660\"
-KERNEL==\"event*\", GROUP=\"$USER\", NAME=\"input/%k\", MODE=\"660\"" \
-| sudo tee /etc/udev/rules.d/99-$USER.rules
+sudo tee /etc/udev/rules.d/99-$USER.rules <<EOF
+KERNEL=="uinput", GROUP="$USER", MODE:="0660"
+KERNEL=="event*", GROUP="$USER", NAME="input/%k", MODE="660"
+EOF
 ```
 
 To apply the changes, you can simply reboot your machine.


### PR DESCRIPTION
Hello, thank you for providing this excellent tool!

Now I am playing with it.

This PR is to adjust the command to create the udev rule file in a more visible way. I thought that the updated command with heredocs as stdin, and without escaping double quotes is easy to maintain and visible to people.

The last line of the README file has a difference, as my editor VIM adds the new line at the end of the file (EOF). Sorry for that.

You can check the modified README below.
https://github.com/junaruga/mouseless/blob/wip/udev-rule-doc/README.md#run-without-root-privileges
